### PR TITLE
added the ebuild for scrcpy 1.14. libsdl2 has to be built with X useflag

### DIFF
--- a/app-mobilephone/scrcpy/scrcpy-1.14.ebuild
+++ b/app-mobilephone/scrcpy/scrcpy-1.14.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit meson ninja-utils git-r3
+
+EGIT_REPO_URI="https://github.com/Genymobile/scrcpy.git"
+
+if [[ ${PV} = 9999* ]]; then
+	MY_SERVER_PV="1.3"
+else
+	EGIT_COMMIT="v${PV}"
+	MY_SERVER_PV="${PV}"
+	KEYWORDS="~amd64"
+fi
+
+MY_SERVER_PN="scrcpy-server"
+MY_SERVER_P="${MY_SERVER_PN}-v${MY_SERVER_PV}"
+
+SRC_URI="https://github.com/Genymobile/${PN}/releases/download/v${MY_SERVER_PV}/${MY_SERVER_P}"
+
+DESCRIPTION="Display and control your Android device"
+HOMEPAGE="https://blog.rom1v.com/2018/03/introducing-scrcpy/"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+IUSE=""
+
+RESTRICT="test"
+
+COMMON_DEPEND="media-libs/libsdl2[X]
+	media-video/ffmpeg"
+DEPEND="${COMMON_DEPEND}"
+RDEPEND="${COMMON_DEPEND}"
+PDEPEND=""
+
+src_configure() {
+	local emesonargs=(
+		-Db_lto=true
+		-Dprebuilt_server="${DISTDIR}/${MY_SERVER_P}"
+	)
+	meson_src_configure
+}


### PR DESCRIPTION
Hi,

scrcpy released [version 1.14](https://github.com/Genymobile/scrcpy/releases). 

media-libs/libsdl2 has to be built with X flag, otherwise scrcpy would not launch with:
CRITICAL: Could not initialize SDL: No available video device